### PR TITLE
Fixing crash with different viewtypes

### DIFF
--- a/recyclerviewenhanced/src/main/java/com/nikhilpanju/recyclerviewenhanced/RecyclerTouchListener.java
+++ b/recyclerviewenhanced/src/main/java/com/nikhilpanju/recyclerviewenhanced/RecyclerTouchListener.java
@@ -528,7 +528,7 @@ public class RecyclerTouchListener implements RecyclerView.OnItemTouchListener, 
                         mLongClickPerformed = false;
                         handler.postDelayed(mLongPressed, LONG_CLICK_DELAY);
                     }
-                    if (swipeable) {
+                    if (swipeable && !unSwipeableRows.contains(touchedPosition)) {
                         mVelocityTracker = VelocityTracker.obtain();
                         mVelocityTracker.addMovement(motionEvent);
                         fgView = touchedView.findViewById(fgViewID);


### PR DESCRIPTION
Now, when marking positions with different viewtypes as unswipeable, it won't crash anymore.